### PR TITLE
Set IsEnabled initially.

### DIFF
--- a/src/crossplatform/SegCtrl.iOS/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.iOS/SegmentedControlRenderer.cs
@@ -64,6 +64,7 @@ namespace Plugin.Segmented.Control.iOS
                 for (int i = 0; i < children.Count; i++)
                 {
                     _nativeControl.InsertSegment(children[i].Text, i, false);
+                    _nativeControl.SetEnabled( children[i].IsEnabled, i );
                 }
 
                 if (!(Element is null))


### PR DESCRIPTION
Problem occurs if we bind the `IsEnabled` property from `SegmentedControlOption` to an existing view model (before segmented control is created) via xaml.