### PR TITLE
Android: Use TextColor instead of TintColor for unselected buttons

### DIFF
--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -319,7 +319,7 @@ namespace Plugin.Segmented.Control.Droid
                 var radioButton = rg.FindViewById(id);
                 var radioId = rg.IndexOfChild(radioButton);
                 var v = (RadioButton)rg.GetChildAt(radioId);
-                var color = Element.IsEnabled ? Element.TintColor.ToAndroid() : Element.DisabledColor.ToAndroid();
+                var color = Element.IsEnabled ? Element.TextColor.ToAndroid() : Element.DisabledColor.ToAndroid();
 
                 _nativeRadioButtonControl?.SetTextColor(color);
 


### PR DESCRIPTION
Should fix bug #83. Use `TextColor` instead of `TintColor` for unselected items.

Successfully tested on Google Pixel 3 with Android 10 and an Android Emulator with Android 8.0.