### PR TITLE
Android: Make sure that BackgroundColor does only affect the buttons, not the whole element

### DIFF
--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -307,7 +307,7 @@ namespace Plugin.Segmented.Control.Droid
 
             unselectedShape.SetStroke(3, color);
 
-            unselectedShape.SetColor(this._unselectedItemBackgroundColor);
+            unselectedShape.SetColor(_unselectedItemBackgroundColor);
 
             radioButton.Enabled = Element.IsEnabled;
         }
@@ -341,8 +341,8 @@ namespace Plugin.Segmented.Control.Droid
 
         public override void SetBackgroundColor(Android.Graphics.Color color)
         {
-            this._unselectedItemBackgroundColor = color;
-            this.OnPropertyChanged();
+            _unselectedItemBackgroundColor = color;
+            OnPropertyChanged();
 
             base.SetBackgroundColor(Android.Graphics.Color.Transparent);
         }

--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -18,6 +18,7 @@ namespace Plugin.Segmented.Control.Droid
     {
         private RadioGroup _nativeControl;
         private RadioButton _nativeRadioButtonControl;
+        private Android.Graphics.Color _unselectedItemBackgroundColor = Android.Graphics.Color.Transparent;
 
         private readonly Context _context;
 
@@ -306,6 +307,8 @@ namespace Plugin.Segmented.Control.Droid
 
             unselectedShape.SetStroke(3, color);
 
+            unselectedShape.SetColor(this._unselectedItemBackgroundColor);
+
             radioButton.Enabled = Element.IsEnabled;
         }
 
@@ -334,6 +337,14 @@ namespace Plugin.Segmented.Control.Droid
         private void OnElementChildrenChanging(object sender, EventArgs e)
         {
             RemoveElementHandlers(true);
+        }
+
+        public override void SetBackgroundColor(Android.Graphics.Color color)
+        {
+            this._unselectedItemBackgroundColor = color;
+            this.OnPropertyChanged();
+
+            base.SetBackgroundColor(Android.Graphics.Color.Transparent);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml
@@ -46,6 +46,7 @@
                     <Button Text="Remove" Clicked="Button_OnClicked"></Button>
                     <Button Text="Tint Color Change Button" Clicked="ButtonTintColor_OnClicked"></Button>
                     <Button Text="Selected Text Change Button" Clicked="ButtonSelectedTextColor_OnClicked"></Button>
+                    <Button Text="Background Color Change Button" Clicked="ButtonBackgroundColor_OnClicked"></Button>
                     <Button Text="Disable Segment Control" Clicked="Disable_OnClicked"></Button>
                     <Button Text="Enable Segment Control" Clicked="Enable_OnClicked"></Button>
                     <Button Text="Change Disabled Color" Clicked="ChangeDisabledColor_OnClicked"></Button>

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
@@ -32,6 +32,11 @@ namespace Test.SegmentedControl
             SegmentedControl.SelectedTextColor = Color.Red;
         }
 
+        private void ButtonBackgroundColor_OnClicked(object sender, EventArgs e)
+        {
+            SegmentedControl.BackgroundColor = Color.HotPink;
+        }
+
         private void Disable_OnClicked(object sender, EventArgs e)
         {
             SegmentedControl.IsEnabled = false;


### PR DESCRIPTION
In version 4.5.1, if a `BackgroundColor` is set for the segmented control, it does not only fill the "boxes" with that color but also the background outside the "boxes":

![Before](https://user-images.githubusercontent.com/20944426/83631629-18571f00-a59e-11ea-9c11-deb73baeb321.png)

This pull request fixes that bug and makes sure that only the "boxes" will be filled with the color, see screenshot below:

![Fixed](https://user-images.githubusercontent.com/20944426/83631776-57857000-a59e-11ea-8460-4c85f5c73118.png)

I also extended the Test-app with a button that changes the `BackgroundColor`-property.

Successfully tested on Google Pixel 3 with Android 10 and an Android Emulator with Android 8.0.
