### PR TITLE
Feature: Added BorderColor and BorderWidth (Android + iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Enjoy! And please don't forget to star this project if you find it useful and/or
 - Bindable Select color
 - Bindable Text color
 - Bindable Disabled color
-- Bindable Border color (Android only)
-- Bindable Border width (Android only)
+- Bindable Border color (Android & iOS only)
+- Bindable Border width (Android & iOS only)
 - Bindable Font size
 - Bindable Font Family
 - Bindable Item Text

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Enjoy! And please don't forget to star this project if you find it useful and/or
 - Bindable Select color
 - Bindable Text color
 - Bindable Disabled color
+- Bindable Border color (Android only)
 - Bindable Font size
 - Bindable Font Family
 - Bindable Item Text
@@ -103,6 +104,7 @@ Here is a great blog post about how to move your PCL to .NET Standard: [Building
                 SelectedSegment="{Binding SelectedSegment, Mode=TwoWay}"
                 TintColor="BlueViolet"
                 SelectedTextColor="White"
+                BorderColor="Black"
                 DisabledColor="Gray"
                 FontSize="Small"
                 FontFamily="{StaticResource PlatformFontName}"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Enjoy! And please don't forget to star this project if you find it useful and/or
 - Bindable Text color
 - Bindable Disabled color
 - Bindable Border color (Android only)
+- Bindable Border width (Android only)
 - Bindable Font size
 - Bindable Font Family
 - Bindable Item Text
@@ -104,8 +105,9 @@ Here is a great blog post about how to move your PCL to .NET Standard: [Building
                 SelectedSegment="{Binding SelectedSegment, Mode=TwoWay}"
                 TintColor="BlueViolet"
                 SelectedTextColor="White"
-                BorderColor="Black"
                 DisabledColor="Gray"
+                BorderColor="Black"
+                BorderWidth="2.0"
                 FontSize="Small"
                 FontFamily="{StaticResource PlatformFontName}"
                 Margin="8,8,8,8"

--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -180,6 +180,7 @@ namespace Plugin.Segmented.Control.Droid
                 case nameof(SegmentedControl.FontSize):
                 case nameof(SegmentedControl.FontFamily):
                 case nameof(SegmentedControl.TextColor):
+                case nameof(SegmentedControl.BorderColor):
                     OnPropertyChanged();
                     break;
 
@@ -298,13 +299,15 @@ namespace Plugin.Segmented.Control.Droid
                 ? drawable1 
                 : (GradientDrawable)((InsetDrawable)children[1]).Drawable;
 
-            var color = Element.IsEnabled ? Element.TintColor.ToAndroid() : Element.DisabledColor.ToAndroid();
+            var backgroundColor = Element.IsEnabled ? Element.TintColor.ToAndroid() : Element.DisabledColor.ToAndroid();
 
-            selectedShape.SetStroke(3, color);
+            var borderColor = Element.BorderColor.HasValue && Element.IsEnabled ? Element.BorderColor.Value.ToAndroid() : backgroundColor;
 
-            selectedShape.SetColor(color);
+            selectedShape.SetStroke(3, borderColor);
 
-            unselectedShape.SetStroke(3, color);
+            selectedShape.SetColor(backgroundColor);
+
+            unselectedShape.SetStroke(3, borderColor);
 
             radioButton.Enabled = Element.IsEnabled;
         }

--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -181,6 +181,7 @@ namespace Plugin.Segmented.Control.Droid
                 case nameof(SegmentedControl.FontFamily):
                 case nameof(SegmentedControl.TextColor):
                 case nameof(SegmentedControl.BorderColor):
+                case nameof(SegmentedControl.BorderWidth):
                     OnPropertyChanged();
                     break;
 
@@ -303,11 +304,13 @@ namespace Plugin.Segmented.Control.Droid
 
             var borderColor = Element.IsEnabled ? Element.BorderColor.ToAndroid() : Element.DisabledColor.ToAndroid();
 
-            selectedShape.SetStroke(3, borderColor);
+            var borderWidthInPixel = ConvertDipToPixel(Element.BorderWidth);
+
+            selectedShape.SetStroke(borderWidthInPixel, borderColor);
 
             selectedShape.SetColor(backgroundColor);
 
-            unselectedShape.SetStroke(3, borderColor);
+            unselectedShape.SetStroke(borderWidthInPixel, borderColor);
 
             radioButton.Enabled = Element.IsEnabled;
         }
@@ -337,6 +340,11 @@ namespace Plugin.Segmented.Control.Droid
         private void OnElementChildrenChanging(object sender, EventArgs e)
         {
             RemoveElementHandlers(true);
+        }
+
+        private int ConvertDipToPixel(double dip)
+        {
+            return (int)Android.Util.TypedValue.ApplyDimension(Android.Util.ComplexUnitType.Dip, (float)dip, _context.Resources.DisplayMetrics);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.Droid/SegmentedControlRenderer.cs
@@ -301,7 +301,7 @@ namespace Plugin.Segmented.Control.Droid
 
             var backgroundColor = Element.IsEnabled ? Element.TintColor.ToAndroid() : Element.DisabledColor.ToAndroid();
 
-            var borderColor = Element.BorderColor.HasValue && Element.IsEnabled ? Element.BorderColor.Value.ToAndroid() : backgroundColor;
+            var borderColor = Element.IsEnabled ? Element.BorderColor.ToAndroid() : Element.DisabledColor.ToAndroid();
 
             selectedShape.SetStroke(3, borderColor);
 
@@ -364,6 +364,7 @@ namespace Plugin.Segmented.Control.Droid
                 return;
             }
         }
+
         /// <summary>
         /// Used for registration with dependency service
         /// </summary>

--- a/src/crossplatform/SegCtrl.iOS/SegmentedControlRenderer.cs
+++ b/src/crossplatform/SegCtrl.iOS/SegmentedControlRenderer.cs
@@ -31,6 +31,7 @@ namespace Plugin.Segmented.Control.iOS
                 SetFont();
                 SetSelectedTextColor();
                 SetTextColor();
+                SetBorder();
             }
 
             if (!(e.OldElement is null))
@@ -189,6 +190,11 @@ namespace Plugin.Segmented.Control.iOS
                 case nameof(SegmentedControl.FontFamily):
                     SetFont();
                     break;
+
+                case nameof(SegmentedControl.BorderWidth):
+                case nameof(SegmentedControl.BorderColor):
+                    SetBorder();
+                    break;
             }
         }
 
@@ -237,6 +243,15 @@ namespace Plugin.Segmented.Control.iOS
             uiTextAttribute.TextColor = Element.SelectedTextColor.ToUIColor();
 
             _nativeControl.SetTitleTextAttributes(uiTextAttribute, UIControlState.Selected);
+        }
+
+        private void SetBorder()
+        {
+            _nativeControl.Layer.BorderWidth = (nfloat)Element.BorderWidth;
+
+            _nativeControl.Layer.BorderColor = Element.IsEnabled ?
+                Element.BorderColor.ToCGColor() :
+                Element.DisabledColor.ToCGColor();
         }
 
         private void NativeControl_SelectionChanged(object sender, EventArgs e)

--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -102,11 +102,11 @@ namespace Plugin.Segmented.Control
             set => SetValue(DisabledColorProperty, value);
         }
 
-        public static readonly BindableProperty BorderColorProperty = BindableProperty.Create(nameof(BorderColor), typeof(Color?), typeof(SegmentedControl));
+        public static readonly BindableProperty BorderColorProperty = BindableProperty.Create(nameof(BorderColor), typeof(Color), typeof(SegmentedControl), defaultValueCreator: bindable => ((SegmentedControl)bindable).TintColor);
 
-        public Color? BorderColor
+        public Color BorderColor
         {
-            get => (Color?)GetValue(BorderColorProperty);
+            get => (Color)GetValue(BorderColorProperty);
             set => SetValue(BorderColorProperty, value);
         }
 

--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -110,8 +110,15 @@ namespace Plugin.Segmented.Control
             set => SetValue(BorderColorProperty, value);
         }
 
-        public static readonly BindableProperty SelectedSegmentProperty = BindableProperty.Create(nameof(SelectedSegment), typeof(int), typeof(SegmentedControl), 0);
+        public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(BorderWidth), typeof(double), typeof(SegmentedControl), 1.0);
 
+        public double BorderWidth
+        {
+            get => (double)GetValue(BorderWidthProperty);
+            set => SetValue(BorderWidthProperty, value);
+        }
+
+        public static readonly BindableProperty SelectedSegmentProperty = BindableProperty.Create(nameof(SelectedSegment), typeof(int), typeof(SegmentedControl), 0);
 
         public int SelectedSegment
         {

--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -110,7 +110,7 @@ namespace Plugin.Segmented.Control
             set => SetValue(BorderColorProperty, value);
         }
 
-        public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(BorderWidth), typeof(double), typeof(SegmentedControl), 1.0);
+        public static readonly BindableProperty BorderWidthProperty = BindableProperty.Create(nameof(BorderWidth), typeof(double), typeof(SegmentedControl), defaultValueCreator: _ => Device.RuntimePlatform == Device.Android ? 1.0 : 0.0);
 
         public double BorderWidth
         {

--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -101,7 +101,15 @@ namespace Plugin.Segmented.Control
             get => (Color)GetValue(DisabledColorProperty);
             set => SetValue(DisabledColorProperty, value);
         }
-        
+
+        public static readonly BindableProperty BorderColorProperty = BindableProperty.Create(nameof(BorderColor), typeof(Color?), typeof(SegmentedControl));
+
+        public Color? BorderColor
+        {
+            get => (Color?)GetValue(BorderColorProperty);
+            set => SetValue(BorderColorProperty, value);
+        }
+
         public static readonly BindableProperty SelectedSegmentProperty = BindableProperty.Create(nameof(SelectedSegment), typeof(int), typeof(SegmentedControl), 0);
 
 

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml
@@ -46,7 +46,7 @@
                     <Button Text="Remove" Clicked="Button_OnClicked"></Button>
                     <Button Text="Tint Color Change Button" Clicked="ButtonTintColor_OnClicked"></Button>
                     <Button Text="Selected Text Change Button" Clicked="ButtonSelectedTextColor_OnClicked"></Button>
-                    <Button Text="Border Color Change Button" Clicked="ButtonBorderColor_OnClicked"></Button>
+                    <Button Text="Change Border Color" Clicked="ButtonBorderColor_OnClicked"></Button>
                     <Button Text="Disable Segment Control" Clicked="Disable_OnClicked"></Button>
                     <Button Text="Enable Segment Control" Clicked="Enable_OnClicked"></Button>
                     <Button Text="Change Disabled Color" Clicked="ChangeDisabledColor_OnClicked"></Button>

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml
@@ -46,6 +46,7 @@
                     <Button Text="Remove" Clicked="Button_OnClicked"></Button>
                     <Button Text="Tint Color Change Button" Clicked="ButtonTintColor_OnClicked"></Button>
                     <Button Text="Selected Text Change Button" Clicked="ButtonSelectedTextColor_OnClicked"></Button>
+                    <Button Text="Border Color Change Button" Clicked="ButtonBorderColor_OnClicked"></Button>
                     <Button Text="Disable Segment Control" Clicked="Disable_OnClicked"></Button>
                     <Button Text="Enable Segment Control" Clicked="Enable_OnClicked"></Button>
                     <Button Text="Change Disabled Color" Clicked="ChangeDisabledColor_OnClicked"></Button>

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml
@@ -47,6 +47,7 @@
                     <Button Text="Tint Color Change Button" Clicked="ButtonTintColor_OnClicked"></Button>
                     <Button Text="Selected Text Change Button" Clicked="ButtonSelectedTextColor_OnClicked"></Button>
                     <Button Text="Change Border Color" Clicked="ButtonBorderColor_OnClicked"></Button>
+                    <Button Text="Change Border Width" Clicked="ButtonBorderWidth_OnClicked"></Button>
                     <Button Text="Disable Segment Control" Clicked="Disable_OnClicked"></Button>
                     <Button Text="Enable Segment Control" Clicked="Enable_OnClicked"></Button>
                     <Button Text="Change Disabled Color" Clicked="ChangeDisabledColor_OnClicked"></Button>

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
@@ -37,6 +37,11 @@ namespace Test.SegmentedControl
             SegmentedControl.BorderColor = Color.Crimson;
         }
 
+        private void ButtonBorderWidth_OnClicked(object sender, EventArgs e)
+        {
+            SegmentedControl.BorderWidth = (SegmentedControl.BorderWidth + 1) % 3;
+        }
+
         private void Disable_OnClicked(object sender, EventArgs e)
         {
             SegmentedControl.IsEnabled = false;

--- a/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
+++ b/src/test/Test.SegCtrl.netstandard/MainPage.xaml.cs
@@ -32,6 +32,11 @@ namespace Test.SegmentedControl
             SegmentedControl.SelectedTextColor = Color.Red;
         }
 
+        private void ButtonBorderColor_OnClicked(object sender, EventArgs e)
+        {
+            SegmentedControl.BorderColor = Color.Crimson;
+        }
+
         private void Disable_OnClicked(object sender, EventArgs e)
         {
             SegmentedControl.IsEnabled = false;


### PR DESCRIPTION
This pull request adds two new properties to the control:

- `BorderColor`
- `BorderWidth`

The properties **can be used on Android and iOS only**, as I do not have an environment set-up to test on UWP and macOS. To inform the consumer of the library about this limitation, I added a note to `README.md`.

The changes are backward-compatible to the current version 4.5.1, i.e. the default-values for the new properties are identical to the ones used in that version. Thanks to this, users upgrading to this version will not notice any visual changes inside their apps.

For testing, I extended the test-application with two new buttons which do change the new properties (similar to the existing code). The proper behaviour has been verified on:

* Android 10.0: Google Pixel 3
* Android 8.0: Emulator
* iOS 13.5: Simulator