### PR TITLE
Set default content property

### DIFF
--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -12,6 +12,7 @@ namespace Plugin.Segmented.Control
 {
     [DesignTimeVisible(true)]
     [Preserve(AllMembers = true)]
+    [ContentProperty(nameof(Children))]
     public class SegmentedControl : View, IViewContainer<SegmentedControlOption>
     {
         public SegmentedControl()


### PR DESCRIPTION
If WidthRequest is set, use it to force the width of the segment.

```csharp
                            <control:SegmentedControl>
                                <control:SegmentedControlOption Text="Item0" WidthRequest="50" />
                                <control:SegmentedControlOption Text="Item1"/>
                                <control:SegmentedControlOption Text="Item2"/>
                            </control:SegmentedControl>

```