### PR TITLE
Fix SelectedItem for string ItemsSource in SegmentedControl

### DIFF
--- a/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
+++ b/src/main/SegCtlr.Netstandard/Control/SegmentedControl.cs
@@ -68,7 +68,7 @@ namespace Plugin.Segmented.Control
 
                 if (textValues != null)
                 {
-                    Children = new List<SegmentedControlOption>(textValues.Select(child => new SegmentedControlOption {Text = child}));
+                    Children = new List<SegmentedControlOption>(textValues.Select(child => new SegmentedControlOption { Text = child, Item = child }));
                     OnSelectedItemChanged(true);
                 }
                 else


### PR DESCRIPTION
## Summary
- ensure SegmentedControl options for string collections store both text and item

## Testing
- `dotnet build src/main/SegCtlr.Netstandard/SegCtlr.Netstandard.csproj`
- `cd /tmp/verify && dotnet run`


------
https://chatgpt.com/codex/tasks/task_e_689eef2fc828832bb160e9bbfeb96479